### PR TITLE
Add symfony environment reporting

### DIFF
--- a/ReleaseStage/ReleaseStageInterface.php
+++ b/ReleaseStage/ReleaseStageInterface.php
@@ -9,13 +9,15 @@
  */
 namespace Evolution7\BugsnagBundle\ReleaseStage;
 
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+
 /**
  * Interface for ReleaseStage classes
  *
  * These classes are used to determine which release stage the application
  * is deployed in
  */
-interface ReleaseStageInterface
+interface ReleaseStageInterface extends ContainerAwareInterface
 {
     /**
      * Returns a textual description of the release stage

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,6 +7,8 @@ parameters:
 services:
     bugsnag.release_stage:
         class: %bugsnag.release_stage.class%
+        calls:
+            - [setContainer, ["@service_container"]]
 
     bugsnag.client:
         class: Bugsnag_Client


### PR DESCRIPTION
This will break backward compatibility since the ReleaseStageInterface now extends ContainerAwareInterface and there is a new DI parameter for the service. This should not affect applications using default configuration though.
