### PR TITLE
Severity for exceptions and shutdowns are getting set to "warning"

### DIFF
--- a/Bugsnag/ClientLoader.php
+++ b/Bugsnag/ClientLoader.php
@@ -78,11 +78,13 @@ class ClientLoader
      * Deal with Exceptions
      *
      * @param \Exception $exception
+     * @param array|null $metadata
+     * @param string $severity
      */
-    public function notifyOnException(\Exception $exception)
+    public function notifyOnException(\Exception $exception, $metadata = null, $severity = 'error')
     {
         if ($this->enabled) {
-            $this->bugsnagClient->notifyException($exception);
+            $this->bugsnagClient->notifyException($exception, $metadata, $severity);
         }
     }
 

--- a/Bugsnag/ClientLoader.php
+++ b/Bugsnag/ClientLoader.php
@@ -93,11 +93,12 @@ class ClientLoader
      *
      * @param string $message  Error message
      * @param array  $metadata Metadata to be provided
+     * @param string|null $severity
      */
-    public function notifyOnError($message, Array $metadata = null)
+    public function notifyOnError($message, Array $metadata = null, $severity = null)
     {
         if ($this->enabled) {
-            $this->bugsnagClient->notifyError('Error', $message, $metadata);
+            $this->bugsnagClient->notifyError('Error', $message, $metadata, $severity);
         }
     }
 }

--- a/EventListener/ShutdownListener.php
+++ b/EventListener/ShutdownListener.php
@@ -64,7 +64,7 @@ class ShutdownListener
         $message   = sprintf($message, $error['message']);
         $backtrace = array(array('file' => $error['file'], 'line' => $error['line']));
 
-        $this->client->notifyOnError($message, $backtrace);
+        $this->client->notifyOnError($message, $backtrace, 'error');
         error_log($message.' in: '.$error['file'].':'.$error['line']);
     }
 }


### PR DESCRIPTION
This is because there is no ability to pass in a severity override and the default in the client is warning.

These types are fatal errors and should be set accordingly.