### PR TITLE
Make sure that json content types pass over their parameters properly.

### DIFF
--- a/Bugsnag/ClientLoader.php
+++ b/Bugsnag/ClientLoader.php
@@ -70,6 +70,12 @@ class ClientLoader
             }
 
             $metaData['Symfony']['Route'] = $request->get('_route');
+
+            // Json types transmit params differently.
+            if ($request->getContentType() == 'json') {
+                $metaData['request']['params'] = $request->request->all();
+            }
+
             $this->bugsnagClient->setMetaData($metaData);
         }
     }


### PR DESCRIPTION
Because of the fact that a JSON content type (say from an API) passes their content in the request body, the bugsnag client will not pick it up automatically. It needs to be set manually in this case, to ensure that the parameters are visible.