### PR TITLE
Implement service reader for userdata in trace

### DIFF
--- a/Bugsnag/ClientLoader.php
+++ b/Bugsnag/ClientLoader.php
@@ -9,6 +9,7 @@
  */
 namespace Evolution7\BugsnagBundle\Bugsnag;
 
+use Evolution7\BugsnagBundle\UserInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Evolution7\BugsnagBundle\ReleaseStage\ReleaseStageInterface;
@@ -44,6 +45,13 @@ class ClientLoader
         $this->bugsnagClient->setReleaseStage($releaseStageClass->get());
         $this->bugsnagClient->setNotifyReleaseStages($container->getParameter('bugsnag.notify_stages'));
         $this->bugsnagClient->setProjectRoot(realpath($container->getParameter('kernel.root_dir').'/..'));
+
+        if ($container->hasParameter('bugsnag.user') && $container->has($container->getParameter('bugsnag.user'))) {
+            $service = $container->get($container->getParameter('bugsnag.user'));
+            if ($service instanceof UserInterface) {
+                $this->bugsnagClient->setUser($service->get());
+            }
+        }
 
         // If the proxy settings are configured, provide these to the Bugsnag client
         if ($container->hasParameter('bugsnag.proxy')) {

--- a/Bugsnag/ClientLoader.php
+++ b/Bugsnag/ClientLoader.php
@@ -49,7 +49,7 @@ class ClientLoader
         if ($container->hasParameter('bugsnag.user') && $container->has($container->getParameter('bugsnag.user'))) {
             $service = $container->get($container->getParameter('bugsnag.user'));
             if ($service instanceof UserInterface) {
-                $this->bugsnagClient->setUser($service->get());
+                $this->bugsnagClient->setUser($service->getUserAsArray());
             }
         }
 

--- a/DependencyInjection/BugsnagExtension.php
+++ b/DependencyInjection/BugsnagExtension.php
@@ -44,6 +44,10 @@ class BugsnagExtension extends Extension
         // Notify stages, default is staging and production
         $container->setParameter('bugsnag.notify_stages', $config['notify_stages']);
 
+        if (!empty($config['user']) && is_string($config['user'])) {
+            $container->setParameter('bugsnag.user', $config['user']);
+        }
+
         // App Version
         if (isset($config['app_version'])) {
             $container->setParameter('bugsnag.app_version', $config['app_version']);

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->scalarNode('api_key')->end()
                 ->scalarNode('app_version')->end()
+                ->scalarNode('user')->defaultNull()->end()
                 ->arrayNode('enabled_stages')
                     ->defaultValue(array('prod'))
                     ->prototype('scalar')->end()

--- a/README.md
+++ b/README.md
@@ -131,7 +131,11 @@ class BugsnagUser implements BugsnagUserInterface
      */
     public function get()
     {
-        if (!$this->token->isAuthenticated() || !$this->token->getUser() instanceof SymfonyUserInterface) {
+        if (
+            is_null($this->token)
+            || !$this->token->isAuthenticated()
+            || !$this->token->getUser() instanceof SymfonyUserInterface
+        ) {
             return [];
         }
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ class BugsnagUser implements BugsnagUserInterface
     /**
      * @inheritdoc
      */
-    public function get()
+    public function getUserAsArray()
     {
         if (
             is_null($this->token)

--- a/UserInterface.php
+++ b/UserInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Evolution7\BugsnagBundle;
+
+interface UserInterface
+{
+
+    /**
+     * The Method must return an array with all userdata that should be sent to
+     * Bugsnag.
+     *
+     * Note: the array keys "id", "name" and "email" will be searchable!
+     *
+     * @return array
+     */
+    public function get();
+
+}

--- a/UserInterface.php
+++ b/UserInterface.php
@@ -13,6 +13,6 @@ interface UserInterface
      *
      * @return array
      */
-    public function get();
+    public function getUserAsArray();
 
 }


### PR DESCRIPTION
Bugsnag allows to send userdata with the notification. Cause not everyone has the same user objects or implementation this should be a good way to support flexible custom users. :smile: Hoping the additional parts in the readme are not too much text. 