### PR TITLE
Add minimal support for Symfony3

### DIFF
--- a/Bugsnag/ClientLoader.php
+++ b/Bugsnag/ClientLoader.php
@@ -69,19 +69,20 @@ class ClientLoader
         );
 
         // Get and add controller information, if available
-        if ($container->isScopeActive('request')) {
-            $request = $container->get('request');
-            $controller = $request->attributes->get('_controller');
+        $currentRequest = $container->get('request_stack')->getCurrentRequest();
+
+        if ($currentRequest) {
+            $controller = $currentRequest->attributes->get('_controller');
 
             if ($controller !== null) {
                 $metaData['Symfony'] = array('Controller' => $controller);
             }
 
-            $metaData['Symfony']['Route'] = $request->get('_route');
+            $metaData['Symfony']['Route'] = $currentRequest->get('_route');
 
             // Json types transmit params differently.
-            if ($request->getContentType() == 'json') {
-                $metaData['request']['params'] = $request->request->all();
+            if ($currentRequest->getContentType() == 'json') {
+                $metaData['request']['params'] = $currentRequest->request->all();
             }
 
             $this->bugsnagClient->setMetaData($metaData);

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,7 +1,7 @@
 evolution7_bugsnag_test_exception:
-    pattern:  /exception
+    path:  /exception
     defaults: { _controller: BugsnagBundle:Default:exception }
 
 evolution7_bugsnag_test_error:
-    pattern: /error
+    path: /error
     defaults: { _controller: BugsnagBundle:Default:error }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -15,22 +15,22 @@ services:
 
     bugsnag.clientloader:
         class: %bugsnag.client.class%
-        arguments: [@bugsnag.client, @bugsnag.release_stage, @service_container]
+        arguments: ['@bugsnag.client', '@bugsnag.release_stage', '@service_container']
 
     bugsnag.exception_console_listener:
         class: %bugsnag.exception_console_listener.class%
-        arguments: [@bugsnag.clientloader]
+        arguments: ['@bugsnag.clientloader']
         tags:
             - { name: kernel.event_listener, event: console.exception }
 
     bugsnag.exception_listener:
         class: %bugsnag.exception_listener.class%
-        arguments: [@bugsnag.clientloader]
+        arguments: ['@bugsnag.clientloader']
         tags:
                     - { name: kernel.event_listener, event: kernel.exception, method: onKernelException }
 
     bugsnag.shutdown_listener:
         class: %bugsnag.shutdown_listener.class%
-        arguments: [@bugsnag.clientloader]
+        arguments: ['@bugsnag.clientloader']
         tags:
                     - { name: kernel.event_listener, event: kernel.controller, method: register }


### PR DESCRIPTION
The new Symfony3 was released some weeks ago. I've tested the bundle using an application using it and the bundle is unusable. These commits make a minimal support for Symfony3.

The `request_stack` service was introduced in the version 2.4, so i think the repository will need to separate the versions 2.* (for <2.4 support) and 3.*.