### PR TITLE
Update composer.json requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,8 @@
     "homepage": "https://github.com/evolution7/Evolution7BugsnagBundle",
     "license": "MIT",
     "require": {
-        "php": ">=5.3.3",
         "bugsnag/bugsnag": "2.*",
-        "symfony/symfony": ">=2.4.0"
+        "symfony/symfony": "~2.4.0|~3.0"
     },
     "autoload": {
         "psr-0": { "Evolution7\\BugsnagBundle": "" }


### PR DESCRIPTION
1. The ``PHP`` requirement is not important because it is already done by the symfony requirements.
2. It is a best practice to use ``~2.4|~3.0`` instead of ``>=2.4.0`` for better readability and to understand in which Symfony version this bundle is already working.